### PR TITLE
Add support large object based on file size

### DIFF
--- a/src/SwiftAdapter.php
+++ b/src/SwiftAdapter.php
@@ -54,7 +54,19 @@ class SwiftAdapter extends AbstractAdapter
 
         $data[$type] = $contents;
 
-        $response = $this->container->createObject($data);
+        // Check large object >3G
+        $metadata = $this->getSize($path);
+        if ($metadata && isset($metadata['size']) && $metadata['size'] > 3221225472) {
+            // optional: specify the size of each segment in bytes - 1GB
+            $options['segmentSize'] = 1073741824;
+            // optional: specify the container where the segments live. This does not necessarily have to be the
+            // same as the container which holds the manifest file
+            $options['segmentContainer'] = $this->container->name;
+
+            $response = $this->container->createLargeObject($data);
+        } else {
+            $response = $this->container->createObject($data);
+        }
 
         return $this->normalizeObject($response);
     }


### PR DESCRIPTION
In the sample of php-opencloud, I see an example to allow create large object in segments (1GB).